### PR TITLE
Unify industrial and github argument syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ In order to run the script you need:
 For example the tests running on https://github.com/PilzDE/psen_scan_v2 use:
 ```
 rosrun pilz_github_ci_runner test_repository.py "PilzDE/psen_scan_v2" \
-rfeistenauer agutenkunst \
---apt_proxy=http://172.20.20.104:3142 \
---docker_opts="-v /usr/local/share/ca-certificates:/usr/local/share/ca-certificates:ro --env HOST_IP=192.168.0.122 --env SENSOR_IP=192.168.0.100" \
+"rfeistenauer agutenkunst" \
 --setup_cmd="usbrelay 1_1=0; sleep 2; usbrelay 1_1=1" --cleanup_cmd="usbrelay 1_1=0" \
 --cmake-args="DENABLE_HARDWARE_TESTING=ON"
+APT_PROXY=http://172.20.20.104:3142 \
+DOCKER_RUN_OPTS="-v /usr/local/share/ca-certificates:/usr/local/share/ca-certificates:ro --env HOST_IP=192.168.0.122 --env SENSOR_IP=192.168.0.100" \
 ```
 For continuous running add a `--loop_time=<seconds_for_refresh>`
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ For example the tests running on https://github.com/PilzDE/psen_scan_v2 use:
 rosrun pilz_github_ci_runner test_repository.py "PilzDE/psen_scan_v2" \
 "rfeistenauer agutenkunst" \
 --setup_cmd="usbrelay 1_1=0; sleep 2; usbrelay 1_1=1" --cleanup_cmd="usbrelay 1_1=0" \
---cmake-args="DENABLE_HARDWARE_TESTING=ON"
+CMAKE_ARGS="DENABLE_HARDWARE_TESTING=ON"
 APT_PROXY=http://172.20.20.104:3142 \
 DOCKER_RUN_OPTS="-v /usr/local/share/ca-certificates:/usr/local/share/ca-certificates:ro --env HOST_IP=192.168.0.122 --env SENSOR_IP=192.168.0.100" \
 ```

--- a/src/pilz_github_ci_runner/hardware_tester.py
+++ b/src/pilz_github_ci_runner/hardware_tester.py
@@ -29,15 +29,10 @@ class HardwareTester(object):
         super().__init__(*args, **kwargs)
         self._token = token
         self._log_dir = log_dir
-        self._env = self._create_ci_env(ci_args)
+        self._env = gather_ci_environment_variables(ci_args)
+        print("CI Environment:", self._env)
         self._setup_cmd = setup_cmd
         self._cleanup_cmd = cleanup_cmd
-
-    def _create_ci_env(self, ci_args):
-        relevant_env = {k: os.environ.get(k) for k in KEYS if k in os.environ}
-        relevant_env.update(ci_args)
-        print("CI Environment:", relevant_env)
-        return relevant_env
 
     def check_prs(self, prs_to_check):
         for pr in prs_to_check:
@@ -75,6 +70,16 @@ class HardwareTester(object):
             "%s\n<details>\n<summary>Output</summary>\n\n```\n%s\n```" % (end_text, result["output"]))
         if self._cleanup_cmd:
             run_command(self._cleanup_cmd)
+
+
+def gather_ci_environment_variables(ci_args):
+    relevant_env = _read_selected_variables_from_os_envirement(KEYS)
+    relevant_env.update(ci_args)
+    return relevant_env
+
+
+def _read_selected_variables_from_os_envirement(selected_keys) -> dict:
+    return {k: os.environ.get(k) for k in selected_keys if k in os.environ}
 
 
 def run_command(command, **kwargs):


### PR DESCRIPTION
## Description

makes the commands for github runner and industrial runner interchangable.

e.g. 
```
rosrun industrial_ci run_ci ROS_DISTRO=noetic ROS_REPO=main DOCKER_RUN_OPTS="-v /usr/local/share/ca-certificates:/usr/local/share/ca-certificates:ro" APT_PROXY="http://172.20.20.104:3142"
```
becomes 
```
rosrun pilz_github_ci_runner test_repository.py "PilzDE/psen_scan_v2" "rfeistenauer agutenkunst" ROS_DISTRO=noetic ROS_REPO=main DOCKER_RUN_OPTS="-v /usr/local/share/ca-certificates:/usr/local/share/ca-certificates:ro" APT_PROXY="http://172.20.20.104:3142"
```