### PR TITLE
Add no keyring option and remove env-var filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For example the tests running on https://github.com/PilzDE/psen_scan_v2 use:
 ```
 rosrun pilz_github_ci_runner test_repository.py "PilzDE/psen_scan_v2" \
 "rfeistenauer agutenkunst" \
---setup_cmd="usbrelay 1_1=0; sleep 2; usbrelay 1_1=1" --cleanup_cmd="usbrelay 1_1=0" \
+--setup-cmd="usbrelay 1_1=0; sleep 2; usbrelay 1_1=1" --cleanup-cmd="usbrelay 1_1=0" \
 CMAKE_ARGS="DENABLE_HARDWARE_TESTING=ON"
 APT_PROXY=http://172.20.20.104:3142 \
 DOCKER_RUN_OPTS="-v /usr/local/share/ca-certificates:/usr/local/share/ca-certificates:ro --env HOST_IP=192.168.0.122 --env SENSOR_IP=192.168.0.100" \

--- a/scripts/test_repository.py
+++ b/scripts/test_repository.py
@@ -20,9 +20,10 @@
 Usage:
     pilz_github_ci_runner.py REPO ALLOWED_USERS [CI_ARGS ...]
         [--log=LOG_DIR]
-        [--setup_cmd=SETUP_CMD]
-        [--cleanup_cmd=SETUP_CMD]
-        [--loop_time=MIN_TIME_IN_SEC]
+        [--setup-cmd=SETUP_CMD]
+        [--cleanup-cmd=SETUP_CMD]
+        [--loop-time=MIN_TIME_IN_SEC]
+        [--no-keyring]
     pilz_github_ci_runner.py set-token
 
    Arguments for the CI can either be set as environment variables or passed as arguments.
@@ -32,10 +33,11 @@ Usage:
 Options:
     -h --help                    Show this
     --log=LOG_DIR                Test log directory [default: ~/.ros/hardware_tests/]
-    --setup_cmd=SETUP_CMD        Command to run before starting industrial_ci e.g. for starting hardware
-    --cleanup_cmd=CLEANUP_CMD    Command to run after industrial_ci has finished e.g. for stopping hardware
-    --loop_time=MIN_TIME_IN_SEC  If set automatically searches valid pull requests and executes the tests continuosly.
+    --setup-cmd=SETUP_CMD        Command to run before starting industrial_ci e.g. for starting hardware
+    --cleanup-cmd=CLEANUP_CMD    Command to run after industrial_ci has finished e.g. for stopping hardware
+    --loop-time=MIN_TIME_IN_SEC  If set automatically searches valid pull requests and executes the tests continuosly.
                                  The argument provided is the minimum repeat time of the loop in seconds.
+    --no-keyring                 Will ask for the token directly, instead of using the keyring.
 """
 
 
@@ -111,7 +113,11 @@ if __name__ == "__main__":
         else:
             exit(0)
 
-    token = get_token()
+    if arguments.get('--no-keyring'):
+        token = getpass(prompt='personal access token:')
+    else:
+        token = get_token()
+
     try:
         gh = github.Github(token)
         test_bot_account = gh.get_user().login
@@ -122,9 +128,9 @@ if __name__ == "__main__":
 
     allowed_users = shlex.split(arguments.get("ALLOWED_USERS"))
     log_dir = os.path.expanduser(arguments.get("--log"))
-    loop_time = arguments.get("--loop_time", None)
-    setup_cmd = arguments.get("--setup_cmd")
-    cleanup_cmd = arguments.get("--cleanup_cmd")
+    loop_time = arguments.get("--loop-time", None)
+    setup_cmd = arguments.get("--setup-cmd")
+    cleanup_cmd = arguments.get("--cleanup-cmd")
 
     ci_args = parse_ci_args(arguments.get("CI_ARGS"))
 

--- a/src/pilz_github_ci_runner/hardware_tester.py
+++ b/src/pilz_github_ci_runner/hardware_tester.py
@@ -21,7 +21,10 @@ import time
 import subprocess
 
 
-KEYS = ["ROS_DISTRO", "ROS_REPO", "DOCKER_RUN_OPTS", "APT_PROXY", "CMAKE_ARGS"]
+KEYS = ["ROS_DISTRO", "ROS_REPO", "DOCKER_RUN_OPTS", "APT_PROXY", "CMAKE_ARGS",
+        "ROS_MASTER_URI", "ROS_PYTHON_VERSION", "ROS_PACKAGE_PATH", "ROS_ROOT",
+        "ROS_VERSION", "ROS_ETC_DIR", "PYTHONPATH", "ROSLISP_PACKAGE_DIRECTORIES",
+        "PATH"]
 
 
 class HardwareTester(object):
@@ -73,7 +76,8 @@ class HardwareTester(object):
 
 
 def gather_ci_environment_variables(ci_args):
-    relevant_env = _read_selected_variables_from_os_envirement(KEYS)
+    # relevant_env = _read_selected_variables_from_os_envirement(KEYS)
+    relevant_env = os.environ.copy()
     relevant_env.update(ci_args)
     return relevant_env
 

--- a/src/pilz_github_ci_runner/hardware_tester.py
+++ b/src/pilz_github_ci_runner/hardware_tester.py
@@ -21,12 +21,6 @@ import time
 import subprocess
 
 
-KEYS = ["ROS_DISTRO", "ROS_REPO", "DOCKER_RUN_OPTS", "APT_PROXY", "CMAKE_ARGS",
-        "ROS_MASTER_URI", "ROS_PYTHON_VERSION", "ROS_PACKAGE_PATH", "ROS_ROOT",
-        "ROS_VERSION", "ROS_ETC_DIR", "PYTHONPATH", "ROSLISP_PACKAGE_DIRECTORIES",
-        "PATH"]
-
-
 class HardwareTester(object):
     def __init__(self, token, log_dir, ci_args, setup_cmd, cleanup_cmd, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -76,14 +70,9 @@ class HardwareTester(object):
 
 
 def gather_ci_environment_variables(ci_args):
-    # relevant_env = _read_selected_variables_from_os_envirement(KEYS)
     relevant_env = os.environ.copy()
     relevant_env.update(ci_args)
     return relevant_env
-
-
-def _read_selected_variables_from_os_envirement(selected_keys) -> dict:
-    return {k: os.environ.get(k) for k in selected_keys if k in os.environ}
 
 
 def run_command(command, **kwargs):


### PR DESCRIPTION
Add an option to directly input the github token
Change option names to align with common pattern
Remove environment variable filter to fix rosrun.