### PR TITLE
Collaps output

### DIFF
--- a/scripts/test_repository.py
+++ b/scripts/test_repository.py
@@ -52,7 +52,6 @@ import docopt
 import contextlib
 
 from pathlib import Path
-from getpass import getpass
 from github.GithubException import RateLimitExceededException, UnknownObjectException, GithubException
 
 sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))

--- a/scripts/test_repository.py
+++ b/scripts/test_repository.py
@@ -41,7 +41,7 @@ Options:
 """
 
 
-from pilz_github_ci_runner import get_testable_pull_requests, ask_user_for_pr_to_check, HardwareTester
+from pilz_github_ci_runner import *
 from pilz_github_ci_runner.print_redirector import PrintRedirector
 
 import os
@@ -49,50 +49,26 @@ import sys
 import time
 import shlex
 import docopt
-import github
 import contextlib
-import keyring
 
 from pathlib import Path
 from getpass import getpass
-from github.GithubException import RateLimitExceededException, UnknownObjectException
+from github.GithubException import RateLimitExceededException, UnknownObjectException, GithubException
 
 sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
 
 
-def set_token():
-    token = None
-    while not token:
-        print(
-            "Please provide a GitHub personal access token with 'public_repo' permission.")
-        new_token = getpass(prompt='personal access token:')
-        keyring.set_password(
-            'system', 'github-hardware-tester-token', new_token)
-        token = keyring.get_password('system', 'github-hardware-tester-token')
-        if not token:
-            print("There was an issue storing the token in the keyring!")
-    return token
+DESCRIPTION = """
+    To enable Testing in a PullRequest(PR) add '- [ ] Perform hardware tests' to your PR description.
 
+    Only internal PRs will be tested by default.
+    To allow testing on PRs from forks, a User in the ALLOWED_USERS list has to accept the head commit of this PR.
+    To allow the head commit write a comment with: 'Allow hw-tests up to commit [sha]'
+        [sha] has to equal the full sha of the last commit in this PR.
 
-def get_token():
-    keyring.set_keyring(
-        keyring.backends.SecretService.Keyring())  # For Ubuntu 20
-    token = keyring.get_password('system', 'github-hardware-tester-token')
-    if not token:
-        token = set_token()
-    return token
+    For further Information see https://github.com/PilzDE/pilz_testutils/pilz_github_ci_runner.
 
-
-def check_and_execute_loop(loop_time):
-    while True:
-        start = time.time()
-        for p in get_testable_pull_requests(repo, allowed_users, test_bot_account):
-            if p.head_is_untested:
-                tester.check_pr(p)
-        end = time.time()
-        remain = int(loop_time) - (end - start)
-        if remain > 0:
-            time.sleep(remain)
+"""
 
 
 def parse_ci_args(cias):
@@ -104,63 +80,60 @@ def parse_ci_args(cias):
     return ci_env
 
 
+def check_and_execute_loop(loop_time, rh):
+    while True:
+        start = time.time()
+        test_prs(rh, manually=False)
+        end = time.time()
+        remain = int(loop_time) - (end - start)
+        if remain > 0:
+            time.sleep(remain)
+
+
+def test_prs(rh, manually=True):
+    try:
+        testable_prs = get_testable_pull_requests(rh)
+        if manually:
+            tester.check_prs(ask_user_for_pr_to_check(testable_prs))
+        else:
+            for p in testable_prs:
+                if p.head_is_untested:
+                    tester.check_pr(p)
+    except RateLimitExceededException:
+        print("Reached a rate limit on Github please try again later.")
+    except GithubException:
+        print("An unspecified Exception from Github had occured.")
+
+
 if __name__ == "__main__":
     arguments = docopt.docopt(__doc__)
     print(arguments, "\n")
+    print(DESCRIPTION)
 
     if arguments.get('set-token'):
-        if set_token():
-            exit(1)
-        else:
-            exit(0)
+        exit(1) if set_token() else exit(0)
 
-    if arguments.get('--no-keyring'):
-        token = getpass(prompt='personal access token:')
-    else:
-        token = get_token()
+    token = get_token(no_keyring=arguments.get('--no-keyring'))
 
+    allowed_users = shlex.split(arguments.get("ALLOWED_USERS"))
     try:
-        gh = github.Github(token)
-        test_bot_account = gh.get_user().login
-        repo = gh.get_repo(arguments.get("REPO"))
+        rh = create_repo_handler(token, arguments.get("REPO"), allowed_users)
     except UnknownObjectException:
         print("Repository not found! Please check the spelling of the REPO argument")
         exit(1)
 
-    allowed_users = shlex.split(arguments.get("ALLOWED_USERS"))
     log_dir = os.path.expanduser(arguments.get("--log"))
     loop_time = arguments.get("--loop-time", None)
-    setup_cmd = arguments.get("--setup-cmd")
-    cleanup_cmd = arguments.get("--cleanup-cmd")
 
-    ci_args = parse_ci_args(arguments.get("CI_ARGS"))
-
-    tester = HardwareTester(ci_args=ci_args,
+    tester = HardwareTester(ci_args=parse_ci_args(arguments.get("CI_ARGS")),
                             token=token,
                             log_dir=log_dir,
-                            setup_cmd=setup_cmd,
-                            cleanup_cmd=cleanup_cmd)
-
-    desciption = """
-    To enable Testing in a PullRequest(PR) add '- [ ] Perform hardware tests' to your PR description.
-
-    Only internal PRs will be tested by default.
-    To allow testing on PRs from forks, a User in the ALLOWED_USERS list has to accept the head commit of this PR.
-    To allow the head commit write a comment with: 'Allow hw-tests up to commit [sha]'
-        [sha] has to equal the full sha of the last commit in this PR.
-
-    For further Information see https://github.com/PilzDE/pilz_testutils/pilz_github_ci_runner.
-
-    """
-    print(desciption)
+                            setup_cmd=arguments.get("--setup-cmd"),
+                            cleanup_cmd=arguments.get("--cleanup-cmd"))
 
     with contextlib.suppress(KeyboardInterrupt):
-        try:
-            with PrintRedirector(Path(log_dir) / Path("stdout.log")):
-                if not loop_time:
-                    tester.check_prs(ask_user_for_pr_to_check(
-                        get_testable_pull_requests(repo, allowed_users, test_bot_account)))
-                else:
-                    check_and_execute_loop(loop_time)
-        except RateLimitExceededException:
-            print("Reached a rate limit on Github please try again later.")
+        with PrintRedirector(Path(log_dir) / Path("stdout.log")):
+            if not loop_time:
+                test_prs(rh)
+            else:
+                check_and_execute_loop(loop_time, rh)

--- a/src/pilz_github_ci_runner/__init__.py
+++ b/src/pilz_github_ci_runner/__init__.py
@@ -1,3 +1,4 @@
-from .github_pr_request_analyzer import get_testable_pull_requests
+from .github_pr_analyzer import get_testable_pull_requests, create_repo_handler
 from .user_interface import ask_user_for_pr_to_check
 from .hardware_tester import HardwareTester
+from .handle_token import set_token, get_token

--- a/src/pilz_github_ci_runner/handle_token.py
+++ b/src/pilz_github_ci_runner/handle_token.py
@@ -1,0 +1,27 @@
+import keyring
+
+
+def set_token():
+    token = None
+    while not token:
+        print(
+            "Please provide a GitHub personal access token with 'public_repo' permission.")
+        new_token = getpass(prompt='personal access token:')
+        keyring.set_password(
+            'system', 'github-hardware-tester-token', new_token)
+        token = keyring.get_password('system', 'github-hardware-tester-token')
+        if not token:
+            print("There was an issue storing the token in the keyring!")
+    return token
+
+
+def get_token(no_keyring):
+    if no_keyring:
+        return getpass(prompt='personal access token:')
+    else:
+        keyring.set_keyring(
+            keyring.backends.SecretService.Keyring())  # For Ubuntu 20
+        token = keyring.get_password('system', 'github-hardware-tester-token')
+        if not token:
+            token = set_token()
+        return token

--- a/src/pilz_github_ci_runner/handle_token.py
+++ b/src/pilz_github_ci_runner/handle_token.py
@@ -1,4 +1,5 @@
 import keyring
+from getpass import getpass
 
 
 def set_token():

--- a/src/pilz_github_ci_runner/hardware_tester.py
+++ b/src/pilz_github_ci_runner/hardware_tester.py
@@ -64,9 +64,9 @@ class HardwareTester(object):
             pr.head.sha, "SUCCESSFULL" if not result["return_code"] else "WITH %s FAILURES" % result["return_code"])
         print(end_text)
 
-        co = collapse_sections(clean_from_unknown_characters(result["output"]))
+        co = collapse_sections(result["output"])
         pr.create_issue_comment(
-            "%s\n<details>\n<summary>Output</summary>\n\n%s\n" % (end_text, co))
+            "%s\n%s" % (end_text, co))
         if self._cleanup_cmd:
             run_command(self._cleanup_cmd)
 

--- a/src/pilz_github_ci_runner/hardware_tester.py
+++ b/src/pilz_github_ci_runner/hardware_tester.py
@@ -66,7 +66,7 @@ class HardwareTester(object):
 
         co = collapse_sections(clean_from_unknown_characters(result["output"]))
         pr.create_issue_comment(
-            "%s\n<details>\n<summary>Output</summary>\n\n```\n%s\n```" % (end_text, co))
+            "%s\n<details>\n<summary>Output</summary>\n\n%s\n" % (end_text, co))
         if self._cleanup_cmd:
             run_command(self._cleanup_cmd)
 

--- a/src/pilz_github_ci_runner/hardware_tester.py
+++ b/src/pilz_github_ci_runner/hardware_tester.py
@@ -17,6 +17,7 @@ from tempfile import TemporaryDirectory
 from pathlib import Path
 from github.PullRequest import PullRequest
 from .print_redirector import PrintRedirector
+from .output_format import clean_from_unknown_characters, collapse_sections
 import os
 import time
 import subprocess
@@ -63,8 +64,9 @@ class HardwareTester(object):
             pr.head.sha, "SUCCESSFULL" if not result["return_code"] else "WITH %s FAILURES" % result["return_code"])
         print(end_text)
 
+        co = collapse_sections(clean_from_unknown_characters(result["output"]))
         pr.create_issue_comment(
-            "%s\n<details>\n<summary>Output</summary>\n\n```\n%s\n```" % (end_text, result["output"]))
+            "%s\n<details>\n<summary>Output</summary>\n\n```\n%s\n```" % (end_text, co))
         if self._cleanup_cmd:
             run_command(self._cleanup_cmd)
 

--- a/src/pilz_github_ci_runner/output_format.py
+++ b/src/pilz_github_ci_runner/output_format.py
@@ -38,7 +38,13 @@ def create_code_blocks(output):
 
 
 def crop_output_to_max_length(output):
-    while len(output) > GITHUB_OUTPUT_CAP:
-        output = re.sub(
-            r'(?<=<\/summary>)(((?!<\/details>).)*\n)+', "", output, count=1)
-    return output
+    REMOVED_MSG = "\nREMOVED SOME LINES FROM OUTPUT TO COMPLY TO COMMENT MAX LENGTH!"
+    deleted = False
+    while len(output) > GITHUB_OUTPUT_CAP - len(REMOVED_MSG):
+        deleted = True
+        output, number_ob_subs = re.subn(
+            r'(?<=<\/summary>)(((?!<\/details>).)*\n)+', "...", output, count=1)
+        if number_ob_subs == 0:
+            return("Could not comply to comment max lenth by erasing section connent for some reason."
+                   "\nPlease check the CI log for further information.")
+    return output + REMOVED_MSG if deleted else output

--- a/src/pilz_github_ci_runner/output_format.py
+++ b/src/pilz_github_ci_runner/output_format.py
@@ -34,7 +34,7 @@ def create_summary_end_and_colorize_result(output):
 
 
 def create_code_blocks(output):
-    return re.sub(r'^---', "\n\n```\n\n", output)
+    return re.sub(r'\n---', "\n\n```\n\n", output)
 
 
 def crop_output_to_max_length(output):

--- a/src/pilz_github_ci_runner/output_format.py
+++ b/src/pilz_github_ci_runner/output_format.py
@@ -1,37 +1,44 @@
-def clean_from_unknown_characters(output: str):
-    new_output = ""
-    deleteMode = False
-    for char in output:
-        if char == "":
-            deleteMode = True
-        if not deleteMode:
-            if char == "":
-                new_output += "\n   "
-            elif char == "":
-                new_output += ""
-            else:
-                new_output += char
-        if deleteMode and char == "m" or char == "K":
-            deleteMode = False
-    return new_output
+import re
+GITHUB_OUTPUT_CAP = 262144
 
 
 def collapse_sections(output):
-    collapsed_outout = ""
-    in_title = False
-    for line in output.split("\n"):
-        if ">" * 60 in line:
-            collapsed_outout += "<details><summary>"
-            in_title = True
-        elif "<" * 60 in line:
-            collapsed_outout += "\n\n</details>\n\n"
-        else:
-            if line.startswith("---"):
-                line = line.replace("---", "\n\n```\n\n")
-            collapsed_outout += line
-            if in_title:
-                collapsed_outout += "</summary>\n\n"
-                in_title = False
-            else:
-                collapsed_outout += "\n"
-    return collapsed_outout.rstrip()
+    output = clean_from_unknown_characters(output)
+    output = create_sections(output)
+    output = create_code_blocks(output)
+    output = crop_output_to_max_length(output)
+    return "<details>\n<summary>Output</summary>\n\n%s\n</details>" % output
+
+
+def clean_from_unknown_characters(output: str):
+    output = re.sub(r'\[\d*(m|K)', "", output)
+    output = re.sub(r'', "\n   ", output)
+    return re.sub(r'', "", output)
+
+
+def create_sections(output):
+    output = re.sub(r'>{62}', "<details><summary>", output)
+    output = re.sub(r'<{62}', "</details>\n", output)
+    return create_summary_end_and_colorize_result(output)
+
+
+def create_summary_end_and_colorize_result(output):
+    lines = output.splitlines(keepends=True)
+    for i, l in enumerate(lines):
+        if "<summary>" in l:
+            lines[i+1] += "</summary>\n\n"
+        if "returned with code '" in l:
+            lines[i] = "```diff\n%s%s\n```\n" % (
+                "+" if "code '0'" in l else "-", l)
+    return "".join(lines)
+
+
+def create_code_blocks(output):
+    return re.sub(r'^---', "\n\n```\n\n", output)
+
+
+def crop_output_to_max_length(output):
+    while len(output) > GITHUB_OUTPUT_CAP:
+        output = re.sub(
+            r'(?<=<\/summary>)(((?!<\/details>).)*\n)+', "", output, count=1)
+    return output

--- a/src/pilz_github_ci_runner/output_format.py
+++ b/src/pilz_github_ci_runner/output_format.py
@@ -1,0 +1,36 @@
+def clean_from_unknown_characters(output: str):
+    new_output = ""
+    deleteMode = False
+    for char in output:
+        if char == "":
+            deleteMode = True
+        if not deleteMode:
+            if char == "":
+                new_output += "\n   "
+            elif char == "":
+                new_output += ""
+            else:
+                new_output += char
+        if deleteMode and char == "m" or char == "K":
+            deleteMode = False
+    return new_output
+
+
+def collapse_sections(output):
+    collapsed_outout = ""
+    in_title = False
+    for line in output.split("\n"):
+        if ">" * 60 in line:
+            collapsed_outout += "<details><summary>"
+            in_title = True
+        elif "<" * 60 in line:
+            collapsed_outout += "\n\n</details>\n\n"
+        else:
+            line = line.replace("---", "\n\n```\n\n")
+            collapsed_outout += line
+            if in_title:
+                collapsed_outout += "</summary>\n\n"
+                in_title = False
+            else:
+                collapsed_outout += "\n"
+    return collapsed_outout.rstrip()

--- a/src/pilz_github_ci_runner/output_format.py
+++ b/src/pilz_github_ci_runner/output_format.py
@@ -30,6 +30,9 @@ def create_summary_end_and_colorize_result(output):
         if "returned with code '" in l:
             lines[i] = "```diff\n%s%s\n```\n" % (
                 "+" if "code '0'" in l else "-", l)
+        if "Summary: " in l and "package finished" not in l:
+            lines[i] = "```diff\n%s%s\n```\n" % (
+                "+" if "0 errors" in l and "0 failures" in l else "-", l)
     return "".join(lines)
 
 

--- a/src/pilz_github_ci_runner/output_format.py
+++ b/src/pilz_github_ci_runner/output_format.py
@@ -26,7 +26,8 @@ def collapse_sections(output):
         elif "<" * 60 in line:
             collapsed_outout += "\n\n</details>\n\n"
         else:
-            line = line.replace("---", "\n\n```\n\n")
+            if line.startswith("---"):
+                line = line.replace("---", "\n\n```\n\n")
             collapsed_outout += line
             if in_title:
                 collapsed_outout += "</summary>\n\n"


### PR DESCRIPTION
Instead of one big chunk in a collapsable output field this PR will have the output separated in several collapsable sections, which in turn are in the collapsable output again.

more or less like this.
```
> Output
   > Fetch image
   fetching successfull with ...
   > Init
   init successfull with ...
   > building
      (0% .....
       10% ....
```

Also adds color to section results
Also crops output to stay in github comment max length by deleting section content from top to bottom