### PR TITLE
Add option to specify ROS_DISTRO using .pilz_github_ci_runner.yml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -18,4 +18,5 @@
   <buildtool_depend>catkin</buildtool_depend>
   <exec_depend>python-github-pip</exec_depend>
   <exec_depend>python3-docopt</exec_depend>
+  <exec_depend>python3-yaml</exec_depend>
 </package>

--- a/scripts/test_repository.py
+++ b/scripts/test_repository.py
@@ -67,6 +67,11 @@ DESCRIPTION = """
     To allow the head commit write a comment with: 'Allow hw-tests up to commit [sha]'
         [sha] has to equal the full sha of the last commit in this PR.
 
+    You can specify the ROS_DISTRO by creating a file .pilz_github_ci_runner.yml containing the line
+    ROS_DISTRO: <your_distro>
+    at the root of your project.
+
+
     For further Information see https://github.com/PilzDE/pilz_testutils/pilz_github_ci_runner.
 
 """

--- a/scripts/test_repository.py
+++ b/scripts/test_repository.py
@@ -24,6 +24,7 @@ Usage:
         [--cleanup-cmd=SETUP_CMD]
         [--loop-time=MIN_TIME_IN_SEC]
         [--no-keyring]
+        [--dry-run]
     pilz_github_ci_runner.py set-token
 
    Arguments for the CI can either be set as environment variables or passed as arguments.
@@ -38,6 +39,7 @@ Options:
     --loop-time=MIN_TIME_IN_SEC  If set automatically searches valid pull requests and executes the tests continuosly.
                                  The argument provided is the minimum repeat time of the loop in seconds.
     --no-keyring                 Will ask for the token directly, instead of using the keyring.
+    --dry-run                    Don't comment on the github pull requests. For testing purposes.
 """
 
 
@@ -96,10 +98,12 @@ if __name__ == "__main__":
                             token=token,
                             log_dir=log_dir,
                             setup_cmd=arguments.get("--setup-cmd"),
-                            cleanup_cmd=arguments.get("--cleanup-cmd"))
+                            cleanup_cmd=arguments.get("--cleanup-cmd"),
+                            dry_run=arguments.get("--dry-run"))
 
     try:
-        check_executor = PRCheckExecutor(token, arguments.get("REPO"), allowed_users, tester)
+        check_executor = PRCheckExecutor(
+            token, arguments.get("REPO"), allowed_users, tester)
     except UnknownObjectException:
         print("Repository not found! Please check the spelling of the REPO argument")
         exit(1)

--- a/src/pilz_github_ci_runner/hardware_tester.py
+++ b/src/pilz_github_ci_runner/hardware_tester.py
@@ -22,6 +22,7 @@ from .output_format import collapse_sections
 import os
 import time
 import subprocess
+import yaml
 
 
 class HardwareTester(object):
@@ -61,6 +62,7 @@ class HardwareTester(object):
                     f"git fetch origin pull/{pr.number}/merge", cwd=repo_dir)
                 _run_command(
                     "git checkout FETCH_HEAD", cwd=repo_dir)
+                _extend_env_from_config_file(repo_dir, self._env)
                 result = run_tests(
                     repo_dir, self._env)
 
@@ -102,6 +104,17 @@ def _run_command(command: str, **kwargs):
     return_code = process.poll()
     print("<"*50)
     return {"return_code": return_code, "output": full_output}
+
+
+def _extend_env_from_config_file(repo_dir, env: {}):
+    config_file = repo_dir + "/.pilz_github_ci_runner.yml"
+    try:
+        with open(config_file, 'r') as f:
+            config = yaml.safe_load(f)
+            env['ROS_DISTRO'] = config['ROS_DISTRO']  # Only ROS_DISTRO allowed
+    except:
+        # Ignore if no file is given. Default given at start of runner will be used. Needed for backward compatibility.
+        pass
 
 
 def run_tests(dir, env: {}):

--- a/src/pilz_github_ci_runner/user_interface.py
+++ b/src/pilz_github_ci_runner/user_interface.py
@@ -15,7 +15,7 @@
 
 import contextlib
 from typing import Sequence
-from .github_pr_analyzer import PullRequestValidator
+from pilz_github_ci_runner.pull_request_validator import PullRequestValidator
 
 
 def ask_user_for_pr_to_check(testable_prs: Sequence[PullRequestValidator]) -> Sequence[PullRequestValidator]:


### PR DESCRIPTION
- [x] Merge after #15 

Allows specifying the `ROS_DISTRO` by creating the file `.pilz_github_ci_runner.yml` with the conents:

```
ROS_DISTRO: <your_distro>
```
e.g.
```
ROS_DISTRO: kinetic
```
it will override the variable if the runner was startet with a defined ROS_DISTRO which then acts a default if a `.pilz_github_ci_runner.yml` is not present. Thus is fully backwards compatible.
